### PR TITLE
Style plantinfo

### DIFF
--- a/__tests__/components/pages/__snapshots__/PlantInfo_test.js.snap
+++ b/__tests__/components/pages/__snapshots__/PlantInfo_test.js.snap
@@ -1,9 +1,190 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PlantInfo Page PlantInfo Page does render 1`] = `
-<View>
-  <Text>
-    PlantInfo Component
-  </Text>
-</View>
+<RCTSafeAreaView
+  emulateUnlessSupported={true}
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#fff",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#5DA25B",
+        "flex": 1,
+        "justifyContent": "center",
+        "width": "100%",
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "fontSize": 40,
+        }
+      }
+    >
+      DILL
+    </Text>
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#654321",
+        "flex": 2.5,
+        "justifyContent": "center",
+        "width": "100%",
+      }
+    }
+  >
+    <Image
+      source={
+        Object {
+          "uri": Object {
+            "testUri": "../../../assets/meet-a-plant-example.jpg",
+          },
+        }
+      }
+      style={
+        Object {
+          "alignItems": "center",
+          "borderRadius": 70,
+          "height": 130,
+          "width": 130,
+        }
+      }
+    />
+  </View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#654321",
+        "flex": 7,
+        "paddingLeft": 30,
+        "paddingRight": 30,
+        "width": "100%",
+      }
+    }
+  >
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "fontSize": 30,
+          "margin": 10,
+          "width": "100%",
+        }
+      }
+    >
+      Lighting:
+      <Text
+        style={
+          Object {
+            "color": "#E3CBB5",
+            "paddingLeft": 10,
+          }
+        }
+      >
+        Full Sun
+      </Text>
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "fontSize": 30,
+          "margin": 10,
+          "width": "100%",
+        }
+      }
+    >
+      How Often To Water:
+      <Text
+        style={
+          Object {
+            "color": "#E3CBB5",
+            "paddingLeft": 10,
+          }
+        }
+      >
+        Every 2 days
+      </Text>
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "fontSize": 30,
+          "margin": 10,
+          "width": "100%",
+        }
+      }
+    >
+      Seed To Harvest:
+      <Text
+        style={
+          Object {
+            "color": "#E3CBB5",
+            "paddingLeft": 10,
+          }
+        }
+      >
+        70 Days
+      </Text>
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "fontSize": 30,
+          "margin": 10,
+          "width": "100%",
+        }
+      }
+    >
+      Root Depth:
+      <Text
+        style={
+          Object {
+            "color": "#E3CBB5",
+            "paddingLeft": 10,
+          }
+        }
+      >
+        2 Inches
+      </Text>
+    </Text>
+    <Text
+      style={
+        Object {
+          "color": "white",
+          "fontSize": 30,
+          "margin": 10,
+          "width": "100%",
+        }
+      }
+    >
+      Perennial/Annual:
+      <Text
+        style={
+          Object {
+            "color": "#E3CBB5",
+            "paddingLeft": 10,
+          }
+        }
+      >
+        Annual
+      </Text>
+    </Text>
+  </View>
+</RCTSafeAreaView>
 `;

--- a/components/PlantItem.js
+++ b/components/PlantItem.js
@@ -12,7 +12,7 @@ export default function PlantItem ({ title, image, searchNavigation }) {
           <Image
             style={styles.meetAPlant}
             source={{uri: image}}
-            />
+          />
           <Text>{title}</Text>
       </View>
     </TouchableHighlight>

--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -15,8 +15,8 @@ const SearchBar = () => (
     <View style={styles.searchButton}>
       <Button
         title='Click to Search'
-        onPress={() => alert("I'm the search button!!")}
-        />
+        onPress={() => alert("I'm the search button!")}
+      />
     </View>
   </View>
 )

--- a/components/navigation/TabNavigation.js
+++ b/components/navigation/TabNavigation.js
@@ -18,7 +18,7 @@ export default function TabNavigation(){
     <Tab.Navigator
       tabBarOptions={{
         showLabel: false,
-        activeBackgroundColor: '#f5b70f',
+        activeBackgroundColor: '#E6B357',
       }}
       >
       <Tab.Screen name="Search" component={SearchStackNavigator} options={{ tabBarIcon: () => searchIcon  }}/>

--- a/components/pages/PlantInfo.js
+++ b/components/pages/PlantInfo.js
@@ -1,12 +1,53 @@
 import React from 'react'
-import { View, Text } from 'react-native'
+import { View, Text, SafeAreaView, Image, Button } from 'react-native'
 
 import styles from '../../styles/styles';
+import plantImg from '../../assets/meet-a-plant-example.jpg';
 
 export default function PlantInfo() {
   return (
-    <View>
-      <Text>PlantInfo Component</Text>
-    </View>
+    <SafeAreaView style={styles.container}>
+      <View style={styles.plantInfoHeader}>
+        <Text style={styles.nameText}>DILL</Text>
+      </View>
+      <View style={styles.plantIconContainer}>
+        <Image
+          style={styles.plantIcon}
+          source={{uri: plantImg}}
+        />
+      </View>
+      <View style={styles.plantInfoContent}>
+        <Text style={styles.textContent}>
+          Lighting:
+            <Text style={{color: '#E3CBB5', paddingLeft: 10, paddingLeft: 10}}>
+              Full Sun
+            </Text>
+        </Text>
+        <Text style={styles.textContent}>
+          How Often To Water:
+            <Text style={{color: '#E3CBB5', paddingLeft: 10}}>
+              Every 2 days
+            </Text>
+        </Text>
+        <Text style={styles.textContent}>
+          Seed To Harvest:
+            <Text style={{color: '#E3CBB5', paddingLeft: 10}}>
+              70 Days
+            </Text>
+        </Text>
+        <Text style={styles.textContent}>
+          Root Depth:
+            <Text style={{color: '#E3CBB5', paddingLeft: 10}}>
+              2 Inches
+            </Text>
+        </Text>
+        <Text style={styles.textContent}>
+          Perennial/Annual:
+            <Text style={{color: '#E3CBB5', paddingLeft: 10}}>
+              Annual
+            </Text>
+        </Text>
+      </View>
+    </SafeAreaView>
   )
 }

--- a/components/pages/Search.js
+++ b/components/pages/Search.js
@@ -33,9 +33,9 @@ export default class Search extends Component {
           ? this.meetThePlant()
           : this.searchResults()}
         </SafeAreaView>
-      )
-    }
-// onPress={() => alert("You have pressed my buttons!")
+    )
+  }
+
   meetThePlant = () => (
     <View style={styles.container}>
       <Text>MEET A NEW PLANT!</Text>

--- a/styles/styles.js
+++ b/styles/styles.js
@@ -9,16 +9,10 @@ export default styles = StyleSheet.create({
     justifyContent: 'center',
   },
   searchInputContainer: {
-    // flex: 1,
-    marginBottom: 10,
+    backgroundColor: '#fff',
+    paddingBottom: 50,
   },
   searchResultsContainer: {
-    // flex: 3,
-    // alignItems: 'center',
-    // borderWidth: 2,
-    // justifyContent: 'space-between',
-    // height: 1000,
-    // overflow: 'scroll',
     marginHorizontal: 20,
   },
   meetAPlant: {
@@ -58,10 +52,48 @@ export default styles = StyleSheet.create({
     borderColor: 'dimgrey',
     height: 30,
     alignSelf: 'center',
-    // alignSelf moves box to middle
   },
   searchButton: {
-    width: 200,
     alignSelf: 'center',
-   }
+    width: 200,
+  },
+  // PLANT INFO PAGE
+  plantInfoHeader: {
+    alignItems: 'center',
+    backgroundColor: '#5DA25B',
+    flex: 1,
+    justifyContent: 'center',
+    width: '100%',
+  },
+  nameText: {
+    color: 'white',
+    fontSize: 40,
+  },
+  plantIconContainer: {
+    alignItems: 'center',
+    backgroundColor: '#654321',
+    flex: 2.5,
+    justifyContent: 'center',
+    width: '100%',
+  },
+  plantIcon: {
+    alignItems: 'center',
+    borderRadius: 70,
+    height: 130,
+    width: 130,
+  },
+  plantInfoContent: {
+    alignItems: 'center',
+    backgroundColor: '#654321',
+    flex: 7,
+    paddingLeft: 30,
+    paddingRight: 30,
+    width: '100%',
+  },
+  textContent: {
+    color: 'white',
+    fontSize: 30,
+    margin: 10,
+    width: '100%',
+  },
 });


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Styling (Styling to new or existing files)
- [ ] Testing
### Detailed Description
We used our previously added mock data to render and style the plant info attributes on the PlantInfo page.

### Why is this change required? What problem does it solve?
As a user, after I click on a plant via my *search results* or *Meet A New Plant*, I see the plant's name, image, and attributes. 

### Was any previously written code changed?
- Replaced the View component, wrapping the page content, with a SafeAreaView component. This prevents content from overlapping when viewed on IOS.

- Replaced the active background color on the bottom nav bar

### Directory modified:
- components/PlantItem.js
- components/navigation/TabNavigation.js 
- styles/styles.js