### PR TITLE
Center plants on My Garden page

### DIFF
--- a/styles/styles.js
+++ b/styles/styles.js
@@ -219,11 +219,9 @@ export default styles = StyleSheet.create({
   },
   myGarden: {
     padding: '5%',
-    paddingBottom: 0,
-
     flexDirection: 'row',
     flexWrap: 'wrap',
-    paddingLeft: '2%',
+    justifyContent: 'center',
   },
   myGardenBody: {
     height: 180,


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Styling (Styling to new or existing files)
- [ ] Testing
### Detailed Description
Aligns plants to the center of My Garden page
### Why is this change required? What problem does it solve?

### Was any previously written code changed?

### Directory modified:
- styles/styles.js